### PR TITLE
Adds a scratchpad output to the A10C II Profile

### DIFF
--- a/Scripts/DCS-ExportScript/ExportsModules/A-10C_2.lua
+++ b/Scripts/DCS-ExportScript/ExportsModules/A-10C_2.lua
@@ -805,6 +805,11 @@ function ExportScript.ProcessIkarusDCSConfigLowImportance(mainPanelDevice)
 	ExportScript.Tools.SendData(2000, string.format("%7.3f", lUHFRadio:get_frequency()/1000000)) -- <- special function for get frequency data
 	ExportScript.Tools.SendData(2000, ExportScript.Tools.RoundFreqeuncy((UHF_RADIO:get_frequency()/1000000))) -- ExportScript.Tools.RoundFreqeuncy(frequency (MHz|KHz), format ("7.3"), PrefixZeros (false), LeastValue (0.025))
 	]]
+
+	-- Export ScratchPad
+	local lScratchPad = ExportScript.Tools.getListIndicatorValue(5)
+        ExportScript.Tools.SendData(2040, ExportScript.Tools.coerce_nil_to_string(lScratchPad.Scratch_PAD))
+
 	-- AN/ARC-164 UHF and UHF Preset Channel
 	---------------------------------------------------
 	local lUHF_RADIO = GetDevice(54)

--- a/Scripts/DCS-ExportScript/lib/Tools.lua
+++ b/Scripts/DCS-ExportScript/lib/Tools.lua
@@ -833,6 +833,16 @@ function ExportScript.Tools.split(stringvalue, delimiter)
     return result;
 end
 
+-- This function turns a 'nil' value into an empty string.
+-- Courtesy of https://github.com/pet333r/pw-dev_script
+function ExportScript.Tools.coerce_nil_to_string(value)
+	if value == nil then
+		return ""
+	else
+		return value
+	end
+end
+
 -- the function checks whether the cockpit light should be activated in ikarus on the basis of the parameters
 -- functional parameters, a single ID, or a table with IDs
 function ExportScript.Tools.IkarusCockpitLights(mainPanelDevice, ExportIDs)


### PR DESCRIPTION
Your fork seems to be the one referenced from the StreamDeck and more up to date than the original. I'd love for you to incorporate this change into your fork, as it's nice to have the A10C's scratchpad up on the stream deck when using the UFC.
